### PR TITLE
feat: add --pattern option to ingest command

### DIFF
--- a/.changeset/ingest-pattern-option.md
+++ b/.changeset/ingest-pattern-option.md
@@ -1,0 +1,17 @@
+---
+"shc2es": minor
+---
+
+Add `--pattern` option to `ingest` command for selective file ingestion
+
+The `ingest` command now accepts a `--pattern` option to specify which files to import:
+
+```bash
+# Import specific files using a glob pattern
+shc2es ingest --pattern "events-2025-12-*.ndjson"
+
+# Import a single file
+shc2es ingest --pattern "events-2025-12-10.ndjson"
+```
+
+Patterns without `/` are relative to the data directory (`~/.shc2es/data/`). Absolute paths are also supported.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ Based on the [Bosch Smart Home Controller II](https://www.bosch-smarthome.com/at
 ```bash
 yarn install          # Install dependencies
 yarn poll             # Start long polling CLI (USER RUNS THIS, NOT AGENT)
+yarn ingest           # Batch import all NDJSON files to Elasticsearch
+yarn ingest --pattern "events-2025-12-*.ndjson"  # Import specific files
 yarn tsc --noEmit     # Type check without emitting
 ```
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ yarn ingest:setup
 # 3. Batch import existing NDJSON files
 yarn ingest
 
+# 3b. Or: import specific files using a glob pattern
+yarn ingest --pattern "events-2025-12-*.ndjson"
+
 # 4. Or: watch for new events and ingest in real-time
 yarn ingest:watch
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ const COMMANDS: Record<
   ingest: {
     description: "Ingest events to Elasticsearch",
     module: "./ingest",
-    usage: "[--setup|--watch]",
+    usage: "[--setup|--watch|--pattern <glob>]",
   },
   registry: {
     description: "Fetch device/room registry from controller",
@@ -63,6 +63,7 @@ Examples:
   shc2es ingest --setup          Setup Elasticsearch indices
   shc2es ingest --watch          Watch and ingest in real-time
   shc2es ingest                  Batch import existing data
+  shc2es ingest --pattern "events-2025-12-*.ndjson"  Import specific files
   shc2es registry                Fetch device registry
   shc2es dashboard --list        List available dashboards
   shc2es dashboard <name>        Export a dashboard

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -569,10 +569,16 @@ async function bulkImportFile(filePath: string): Promise<number> {
   });
 }
 
-async function batchImport(): Promise<void> {
-  log.info("Starting batch import");
+async function batchImport(pattern?: string): Promise<void> {
+  const globPattern = pattern
+    ? pattern.includes("/")
+      ? pattern
+      : `${DATA_DIR}/${pattern}`
+    : `${DATA_DIR}/events-*.ndjson`;
 
-  const files = await glob(`${DATA_DIR}/events-*.ndjson`);
+  log.info({ pattern: globPattern }, "Starting batch import");
+
+  const files = await glob(globPattern);
 
   if (files.length === 0) {
     log.info({ dataDir: DATA_DIR }, "No NDJSON files found in data directory");
@@ -683,7 +689,13 @@ async function main(): Promise<void> {
   } else if (args.includes("--watch")) {
     watchAndTail();
   } else {
-    await batchImport();
+    // Parse --pattern option
+    const patternIndex = args.indexOf("--pattern");
+    const pattern =
+      patternIndex !== -1 && args[patternIndex + 1]
+        ? args[patternIndex + 1]
+        : undefined;
+    await batchImport(pattern);
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `--pattern` option to `yarn ingest` command for selective file ingestion
- Patterns without `/` are relative to the data directory (`~/.shc2es/data/`)
- Absolute paths are also supported

## Usage

```bash
# Import all files (default behavior)
yarn ingest

# Import specific files using a glob pattern
yarn ingest --pattern "events-2025-12-*.ndjson"

# Import a single file
yarn ingest --pattern "events-2025-12-10.ndjson"
```

## Test plan

- [ ] Run `yarn tsc --noEmit` to verify types
- [ ] Test `yarn ingest` without pattern (should use default)
- [ ] Test `yarn ingest --pattern "events-*.ndjson"` (relative pattern)
- [ ] Test with absolute path pattern