### PR TITLE
ci: use GitHub App token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,17 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -59,4 +67,4 @@ jobs:
           publish: yarn release
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Use GitHub App token instead of `GITHUB_TOKEN` in the release workflow
- This allows PRs created by the changesets action to trigger CI workflows
- Fixes issue where release PRs were stuck waiting for required status checks

## Changes

- Add `actions/create-github-app-token@v1` step to generate app token
- Pass app token to `actions/checkout` for git operations
- Use app token for changesets action instead of `GITHUB_TOKEN`

## Setup required

Repository must have:
- Variable: `APP_ID` - GitHub App ID
- Secret: `APP_PRIVATE_KEY` - GitHub App private key

## Test plan

- [ ] Merge a PR with a changeset to main
- [ ] Verify the release PR triggers CI workflows (build 20, build 22)
- [ ] Verify release PR can be merged once checks pass